### PR TITLE
Support use from GUI apps or if stdin/stdout redirected

### DIFF
--- a/conpty.go
+++ b/conpty.go
@@ -124,6 +124,7 @@ func getStartupInfoExForPTY(hpc _HPCON) (*_StartupInfoEx, error) {
 	}
 	var siEx _StartupInfoEx
 	siEx.startupInfo.Cb = uint32(unsafe.Sizeof(windows.StartupInfo{}) + unsafe.Sizeof(&siEx.attributeList[0]))
+	siEx.startupInfo.Flags |= windows.STARTF_USESTDHANDLES
 	var size uintptr
 
 	// first call is to get required size. this should return false.


### PR DESCRIPTION
This commit adds support for running programs using ConPTY even when the parent program is a Windows GUI application or if the parent program's stdin or stdout is redirected. 

The fix implemented here is the one suggested in:

https://github.com/microsoft/terminal/issues/11276

I noticed this when I was trying to use your conpty package from a WIndows GUI application created with gio.