### PR TITLE
Add `Pid()` to get the processId associated

### DIFF
--- a/conpty.go
+++ b/conpty.go
@@ -248,6 +248,10 @@ func (cpty *ConPty) Write(p []byte) (int, error) {
 	return cpty.cmdIn.Write(p)
 }
 
+func (cpty *ConPty) Pid() (uint32) {
+	return cpty.pi.ProcessId
+}
+
 type conPtyArgs struct {
 	coords  _COORD
 	workDir string

--- a/conpty.go
+++ b/conpty.go
@@ -248,8 +248,8 @@ func (cpty *ConPty) Write(p []byte) (int, error) {
 	return cpty.cmdIn.Write(p)
 }
 
-func (cpty *ConPty) Pid() (uint32) {
-	return cpty.pi.ProcessId
+func (cpty *ConPty) Pid() int {
+	return int(cpty.pi.ProcessId)
 }
 
 type conPtyArgs struct {


### PR DESCRIPTION
I'm building a tool which needs to track the started cpty process. try adding a function that provide the pid of it.